### PR TITLE
Fix the Godot 4 bug where object space is incorrectly calculated

### DIFF
--- a/Godot4/ObjectSpaceDissolve.gdshader
+++ b/Godot4/ObjectSpaceDissolve.gdshader
@@ -19,7 +19,7 @@ varying vec3 world_pos;
 varying smooth vec3 vertexOS;
 void vertex()
 {
-	vertexOS = (vec4(VERTEX, 1.0) * MODEL_MATRIX).xyz;
+	vertexOS = VERTEX;
 }
 
 void fragment() {

--- a/Godot4/ObjectSpaceDissolve.gdshader
+++ b/Godot4/ObjectSpaceDissolve.gdshader
@@ -16,10 +16,16 @@ uniform vec2 textureUVScale = vec2(1.);
 const float tao = 2. * 3.14;
 
 varying vec3 world_pos;
+varying smooth vec3 vertexOS;
+void vertex()
+{
+	vertexOS = (vec4(VERTEX, 1.0) * MODEL_MATRIX).xyz;
+}
 
 void fragment() {
 	// TODO: fix this for Godot 4 - it's not keeping in Object Space, if the camera or the object moves, the dissolve is also affected
 	vec3 position = (inverse(MODEL_MATRIX) * vec4(VERTEX, 1.0)).xyz;
+	position = vertexOS;
 	
 	vec4 text = texture(texture, UV);
 	vec4 blend = texture(blendTexture, UV * blendUVScale);

--- a/Godot4/ObjectSpaceDissolve.gdshader
+++ b/Godot4/ObjectSpaceDissolve.gdshader
@@ -23,9 +23,7 @@ void vertex()
 }
 
 void fragment() {
-	// TODO: fix this for Godot 4 - it's not keeping in Object Space, if the camera or the object moves, the dissolve is also affected
-	vec3 position = (inverse(MODEL_MATRIX) * vec4(VERTEX, 1.0)).xyz;
-	position = vertexOS;
+	vec3 position = vertexOS;
 	
 	vec4 text = texture(texture, UV);
 	vec4 blend = texture(blendTexture, UV * blendUVScale);

--- a/Godot4/project.godot
+++ b/Godot4/project.godot
@@ -13,3 +13,7 @@ config_version=5
 config/name="GodotObjectSpaceDissolveShader"
 config/features=PackedStringArray("4.0", "Forward Plus")
 config/icon="res://icon.svg"
+
+[dotnet]
+
+project/assembly_name="GodotObjectSpaceDissolveShader"


### PR DESCRIPTION
Also did the matrix multiplication in `vertex` function so that the result is calculated per-vertex and then interpolated across the fragments.

Final result:

https://user-images.githubusercontent.com/81257780/197825079-1acbcf8f-ce59-40dd-9adf-8d7a7424f4de.mp4